### PR TITLE
SerializationService

### DIFF
--- a/AdvancedSystems.Core.Abstractions/ICachingService.cs
+++ b/AdvancedSystems.Core.Abstractions/ICachingService.cs
@@ -23,7 +23,7 @@ public interface ICachingService
     /// <param name="value">
     ///     The values to set in the cache.
     /// </param>
-    /// <param name="jsonTypeInfo">
+    /// <param name="typeInfo">
     ///     The metadata for the specified type.
     /// </param>
     /// <param name="cancellationToken">
@@ -32,7 +32,7 @@ public interface ICachingService
     /// <returns>
     ///     A ValueTask representing the asynchronous operation.
     /// </returns>
-    ValueTask SetAsync<T>(string key, T value, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default) where T : class;
+    ValueTask SetAsync<T>(string key, T value, JsonTypeInfo<T> typeInfo, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>
     ///     Sets a values in the cache asynchronously.
@@ -46,7 +46,7 @@ public interface ICachingService
     /// <param name="value">
     ///     The values to set in the cache.
     /// </param>
-    /// <param name="jsonTypeInfo">
+    /// <param name="typeInfo">
     ///     The metadata for the specified type.
     /// </param>
     /// <param name="options">
@@ -58,7 +58,7 @@ public interface ICachingService
     /// <returns>
     ///     A ValueTask representing the asynchronous operation.
     /// </returns>
-    ValueTask SetAsync<T>(string key, T value, JsonTypeInfo<T> jsonTypeInfo, CacheOptions options, CancellationToken cancellationToken = default) where T : class;
+    ValueTask SetAsync<T>(string key, T value, JsonTypeInfo<T> typeInfo, CacheOptions options, CancellationToken cancellationToken = default) where T : class;
 
     /// <summary>
     ///     Gets a values from the cache asynchronously.
@@ -69,7 +69,7 @@ public interface ICachingService
     /// <param name="key">
     ///     A string identifying the requested values.
     /// </param>
-    /// <param name="jsonTypeInfo">
+    /// <param name="typeInfo">
     ///     The metadata for the specified type.
     /// </param>
     /// <param name="cancellationToken">
@@ -79,7 +79,7 @@ public interface ICachingService
     ///     A ValueTask containing the result of type <typeparamref name="T"/> representing the asynchronous
     ///     operation. The result is null if <paramref name="key"/> can not be identified in the cache.
     /// </returns>
-    ValueTask<T?> GetAsync<T>(string key, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default) where T : class;
+    ValueTask<T?> GetAsync<T>(string key, JsonTypeInfo<T> typeInfo, CancellationToken cancellationToken = default) where T : class;
 
     #endregion
 }

--- a/AdvancedSystems.Core.Abstractions/ISerializationService.cs
+++ b/AdvancedSystems.Core.Abstractions/ISerializationService.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace AdvancedSystems.Core.Abstractions;
+
+/// <summary>
+///     Defines functionality to serialize objects to UTF-8 encoded JSON and deserialize UTF-8 encoded JSON into objects.
+/// </summary>
+public interface ISerializationService
+{
+    #region Methods
+
+    /// <summary>
+    ///     Converts the provided value into a <see cref="string"/>.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The type of the value to serialize.
+    /// </typeparam>
+    /// <param name="value">
+    ///     The <paramref name="value"/> to convert and write.
+    /// </param>
+    /// <param name="typeInfo">
+    ///     The metadata for the specified type.
+    /// </param>
+    /// <returns>
+    ///     A <seealso cref="string"/> representation of the <paramref name="value"/>.
+    /// </returns>
+    /// <exception cref="NotSupportedException">
+    ///     There is no compatible <seealso cref="JsonConverter"/> for <typeparamref name="T"/> or its serializable members.
+    /// </exception>
+    ReadOnlySpan<byte> Serialize<T>(T value, JsonTypeInfo<T> typeInfo) where T : class;
+
+    /// <summary>
+    ///     Parses the text representing a single JSON value into a <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The type to deserialize the JSON value into.
+    /// </typeparam>
+    /// <param name="buffer">
+    ///     JSON text to parse.
+    /// </param>
+    /// <param name="typeInfo">
+    ///     The metadata for the specified type.
+    /// </param>
+    /// <returns>
+    ///     A <typeparamref name="T"/> representation of the JSON value.
+    /// </returns>
+    /// <exception cref="JsonException">
+    ///     The JSON is invalid, <typeparamref name="T"/> is not compatible with the JSON, or there is remaining data in the Stream.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    ///     There is no compatible <seealso cref="JsonConverter"/> for <typeparamref name="T"/> or its serializable members.
+    /// </exception>
+    T? Deserialize<T>(ReadOnlySpan<byte> buffer, JsonTypeInfo<T> typeInfo) where T : class;
+
+    #endregion
+}

--- a/AdvancedSystems.Core.Abstractions/ISerializationService.cs
+++ b/AdvancedSystems.Core.Abstractions/ISerializationService.cs
@@ -30,7 +30,7 @@ public interface ISerializationService
     /// <exception cref="NotSupportedException">
     ///     There is no compatible <seealso cref="JsonConverter"/> for <typeparamref name="T"/> or its serializable members.
     /// </exception>
-    ReadOnlySpan<byte> Serialize<T>(T value, JsonTypeInfo<T> typeInfo) where T : class;
+    byte[] Serialize<T>(T value, JsonTypeInfo<T> typeInfo) where T : class;
 
     /// <summary>
     ///     Parses the text representing a single JSON value into a <typeparamref name="T"/>.
@@ -53,7 +53,7 @@ public interface ISerializationService
     /// <exception cref="NotSupportedException">
     ///     There is no compatible <seealso cref="JsonConverter"/> for <typeparamref name="T"/> or its serializable members.
     /// </exception>
-    T? Deserialize<T>(ReadOnlySpan<byte> buffer, JsonTypeInfo<T> typeInfo) where T : class;
+    T? Deserialize<T>(byte[] buffer, JsonTypeInfo<T> typeInfo) where T : class;
 
     #endregion
 }

--- a/AdvancedSystems.Core.Tests/Common/ObjectSerializerTests.cs
+++ b/AdvancedSystems.Core.Tests/Common/ObjectSerializerTests.cs
@@ -10,7 +10,7 @@ public class ObjectSerializerTests
     #region Tests
 
     [Fact]
-    public void TestSerializationRoundtrip_HappyPath()
+    public void TestSerializationRoundtrip()
     {
         // Arrange
         var expected = new Person("Stefan", "Greve");

--- a/AdvancedSystems.Core.Tests/Common/ObjectSerializerTests.cs
+++ b/AdvancedSystems.Core.Tests/Common/ObjectSerializerTests.cs
@@ -1,0 +1,28 @@
+﻿using AdvancedSystems.Core.Common;
+using AdvancedSystems.Core.Tests.Models;
+
+using Xunit;
+
+namespace AdvancedSystems.Core.Tests.Common;
+
+public class ObjectSerializerTests
+{
+    #region Tests
+
+    [Fact]
+    public void TestSerializationRoundtrip_HappyPath()
+    {
+        // Arrange
+        var expected = new Person("Stefan", "Greve");
+
+        // Act
+        var serialized = ObjectSerializer.Serialize(expected, PersonContext.Default.Person);
+        Person? actual = ObjectSerializer.Deserialize(serialized, PersonContext.Default.Person);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(expected, actual);
+    }
+
+    #endregion
+}

--- a/AdvancedSystems.Core.Tests/Fixtures/CachingServiceFixture.cs
+++ b/AdvancedSystems.Core.Tests/Fixtures/CachingServiceFixture.cs
@@ -47,12 +47,14 @@ public sealed class CachingServiceFixture
             })
             .Returns(Task.CompletedTask);
 
-        this.CachingService = new CachingService(this.DistributedCache.Object);
+        this.CachingService = new CachingService(this.DistributedCache.Object, this.SerializationService.Object);
     }
 
     #region Properties
 
-    public Mock<IDistributedCache> DistributedCache { get; private set; } = new Mock<IDistributedCache>();
+    public Mock<IDistributedCache> DistributedCache { get; private set; } = new();
+
+    public Mock<ISerializationService> SerializationService { get; private set; } = new();
 
     public ICachingService CachingService { get; private set; }
 

--- a/AdvancedSystems.Core.Tests/Fixtures/SerializationServiceFixture.cs
+++ b/AdvancedSystems.Core.Tests/Fixtures/SerializationServiceFixture.cs
@@ -1,0 +1,18 @@
+﻿using AdvancedSystems.Core.Abstractions;
+using AdvancedSystems.Core.Services;
+
+namespace AdvancedSystems.Core.Tests.Fixtures;
+
+public class SerializationServiceFixture
+{
+    public SerializationServiceFixture()
+    {
+        this.SerializationService = new SerializationService();
+    }
+
+    #region Properties
+
+    public ISerializationService SerializationService { get; private set; }
+
+    #endregion
+}

--- a/AdvancedSystems.Core.Tests/Models/Person.cs
+++ b/AdvancedSystems.Core.Tests/Models/Person.cs
@@ -4,6 +4,5 @@ namespace AdvancedSystems.Core.Tests.Models;
 
 internal record Person(string FirstName, string LastName);
 
-[JsonSourceGenerationOptions(/*GenerationMode = JsonSourceGenerationMode.Default*/)]
 [JsonSerializable(typeof(Person), GenerationMode = JsonSourceGenerationMode.Default)]
 internal partial class PersonContext : JsonSerializerContext;

--- a/AdvancedSystems.Core.Tests/Models/Person.cs
+++ b/AdvancedSystems.Core.Tests/Models/Person.cs
@@ -4,6 +4,6 @@ namespace AdvancedSystems.Core.Tests.Models;
 
 internal record Person(string FirstName, string LastName);
 
-[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default)]
-[JsonSerializable(typeof(Person))]
+[JsonSourceGenerationOptions(/*GenerationMode = JsonSourceGenerationMode.Default*/)]
+[JsonSerializable(typeof(Person), GenerationMode = JsonSourceGenerationMode.Default)]
 internal partial class PersonContext : JsonSerializerContext;

--- a/AdvancedSystems.Core.Tests/Models/Person.cs
+++ b/AdvancedSystems.Core.Tests/Models/Person.cs
@@ -1,0 +1,9 @@
+﻿using System.Text.Json.Serialization;
+
+namespace AdvancedSystems.Core.Tests.Models;
+
+internal record Person(string FirstName, string LastName);
+
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default)]
+[JsonSerializable(typeof(Person))]
+internal partial class PersonContext : JsonSerializerContext;

--- a/AdvancedSystems.Core.Tests/Services/CachingServiceTests.cs
+++ b/AdvancedSystems.Core.Tests/Services/CachingServiceTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using AdvancedSystems.Core.Abstractions;
 using AdvancedSystems.Core.DependencyInjection;
 using AdvancedSystems.Core.Tests.Fixtures;
+using AdvancedSystems.Core.Tests.Models;
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -27,8 +28,6 @@ public class CachingServiceTests : IClassFixture<CachingServiceFixture>
         this._fixture = fixture;
     }
 
-    public record Person(string FirstName, string LastName);
-
     #region Tests
 
     [Fact]
@@ -43,8 +42,8 @@ public class CachingServiceTests : IClassFixture<CachingServiceFixture>
         };
 
         // Act
-        await this._fixture.CachingService.SetAsync(key, expected, options, CancellationToken.None);
-        Person? actual = await this._fixture.CachingService.GetAsync<Person>(key, CancellationToken.None);
+        await this._fixture.CachingService.SetAsync(key, expected, PersonContext.Default.Person, options, CancellationToken.None);
+        Person? actual = await this._fixture.CachingService.GetAsync(key, PersonContext.Default.Person, CancellationToken.None);
 
         // Assert
         Assert.NotNull(actual);
@@ -60,8 +59,8 @@ public class CachingServiceTests : IClassFixture<CachingServiceFixture>
         var expected = new Person("Stefan", "Greve");
 
         // Act
-        await this._fixture.CachingService.SetAsync("test1", expected, CancellationToken.None);
-        Person? actual = await this._fixture.CachingService.GetAsync<Person>("test2", CancellationToken.None);
+        await this._fixture.CachingService.SetAsync("test1", expected, PersonContext.Default.Person, CancellationToken.None);
+        Person? actual = await this._fixture.CachingService.GetAsync("test2", PersonContext.Default.Person, CancellationToken.None);
 
         // Assert
         Assert.Null(actual);

--- a/AdvancedSystems.Core.Tests/Services/CachingServiceTests.cs
+++ b/AdvancedSystems.Core.Tests/Services/CachingServiceTests.cs
@@ -34,6 +34,7 @@ public class CachingServiceTests : IClassFixture<CachingServiceFixture>
     public async Task TestCachingRoundtrip_HappyPath()
     {
         // Arrange
+        this._fixture.DistributedCache.Invocations.Clear();
         string key = "test";
         var expected = new Person("Stefan", "Greve");
         var options = new CacheOptions
@@ -49,13 +50,14 @@ public class CachingServiceTests : IClassFixture<CachingServiceFixture>
         Assert.NotNull(actual);
         Assert.Equal(expected.FirstName, actual?.FirstName);
         Assert.Equal(expected.LastName, actual?.LastName);
-        this._fixture.DistributedCache.Verify(service => service.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+        this._fixture.DistributedCache.Verify(service => service.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task TestCachingRoundtrip_UnhappyPath()
     {
         // Arrange
+        this._fixture.DistributedCache.Invocations.Clear();
         var expected = new Person("Stefan", "Greve");
 
         // Act
@@ -64,7 +66,7 @@ public class CachingServiceTests : IClassFixture<CachingServiceFixture>
 
         // Assert
         Assert.Null(actual);
-        this._fixture.DistributedCache.Verify(service => service.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+        this._fixture.DistributedCache.Verify(service => service.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/AdvancedSystems.Core.Tests/Services/SerializationServiceTests.cs
+++ b/AdvancedSystems.Core.Tests/Services/SerializationServiceTests.cs
@@ -1,0 +1,71 @@
+﻿using System.Threading.Tasks;
+
+using AdvancedSystems.Core.Abstractions;
+using AdvancedSystems.Core.DependencyInjection;
+using AdvancedSystems.Core.Tests.Fixtures;
+using AdvancedSystems.Core.Tests.Models;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Xunit;
+
+namespace AdvancedSystems.Core.Tests.Services;
+
+public class SerializationServiceTests : IClassFixture<SerializationServiceFixture>
+{
+    private readonly SerializationServiceFixture _sut;
+
+    public SerializationServiceTests(SerializationServiceFixture fixture)
+    {
+        this._sut = fixture;
+    }
+
+    #region Tests
+
+    [Fact]
+    public void TestSerializationRoundtrip()
+    {
+        // Arrange
+        var expected = new Person("Stefan", "Greve");
+
+        // Act
+        var serialized = this._sut.SerializationService.Serialize(expected, PersonContext.Default.Person);
+        var actual = this._sut.SerializationService.Deserialize(serialized, PersonContext.Default.Person);
+
+        // Assert
+        Assert.NotNull(actual);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task TestAddSerializationService()
+    {
+        // Arrange
+        using var hostBuilder = await new HostBuilder()
+            .ConfigureWebHost(builder =>
+            {
+                builder.UseTestServer();
+                builder.ConfigureServices(services =>
+                {
+                    services.AddSerializationService();
+                });
+                builder.Configure(app =>
+                {
+
+                });
+            })
+            .StartAsync();
+
+        // Act
+        var serializationService = hostBuilder.Services.GetService<ISerializationService>();
+
+        // Assert
+        Assert.NotNull(serializationService);
+        await hostBuilder.StopAsync();
+    }
+
+    #endregion
+}

--- a/AdvancedSystems.Core/AdvancedSystems.Core.csproj
+++ b/AdvancedSystems.Core/AdvancedSystems.Core.csproj
@@ -8,7 +8,7 @@
     <Title>Advanced Systems Core Library</Title>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AdvancedSystems.Core.Abstractions" Version="8.0.0-alpha.8" />
+    <PackageReference Include="AdvancedSystems.Core.Abstractions" Version="8.0.0-alpha.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />

--- a/AdvancedSystems.Core/AdvancedSystems.Core.csproj
+++ b/AdvancedSystems.Core/AdvancedSystems.Core.csproj
@@ -8,7 +8,7 @@
     <Title>Advanced Systems Core Library</Title>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AdvancedSystems.Core.Abstractions" Version="8.0.0-alpha.6" />
+    <PackageReference Include="AdvancedSystems.Core.Abstractions" Version="8.0.0-alpha.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />

--- a/AdvancedSystems.Core/Common/ObjectSerializer.cs
+++ b/AdvancedSystems.Core/Common/ObjectSerializer.cs
@@ -19,7 +19,7 @@ public static class ObjectSerializer
         return buffer.WrittenSpan;
     }
 
-    /// <inheritdoc cref="ISerializationService.Deserialize{T}(ReadOnlySpan{byte}, JsonTypeInfo{T})" />
+    /// <inheritdoc cref="ISerializationService.Deserialize{T}(byte[], JsonTypeInfo{T})" />
     public static T? Deserialize<T>(ReadOnlySpan<byte> buffer, JsonTypeInfo<T> typeInfo) where T : class
     {
         return JsonSerializer.Deserialize(buffer, typeInfo); 

--- a/AdvancedSystems.Core/Common/ObjectSerializer.cs
+++ b/AdvancedSystems.Core/Common/ObjectSerializer.cs
@@ -1,41 +1,27 @@
 ﻿using System;
 using System.Buffers;
 using System.Text.Json;
-using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+using AdvancedSystems.Core.Abstractions;
 
 namespace AdvancedSystems.Core.Common;
 
-/// <summary>
-///     Provides functionality to serialize objects to UTF-8 encoded JSON and deserialize UTF-8 encoded JSON into objects.
-/// </summary>
+/// <inheritdoc cref="ISerializationService" />
 public static class ObjectSerializer
 {
-    /// <summary>
-    ///     Converts the provided value into a <seealso cref="string"/>.
-    /// </summary>
-    /// <typeparam name="T">The type of the value to serialize.</typeparam>
-    /// <param name="value">The <paramref name="value"/> to convert and write.</param>
-    /// <returns>A <seealso cref="string"/> representation of the <paramref name="value"/>.</returns>
-    /// <exception cref="NotSupportedException">There is no compatible <seealso cref="JsonConverter"/> for <typeparamref name="T"/> or its serializable members.</exception>
-    public static ReadOnlySpan<byte> Serialize<T>(T value) where T : class
+    /// <inheritdoc cref="ISerializationService.Serialize{T}(T, JsonTypeInfo{T})" />
+    public static ReadOnlySpan<byte> Serialize<T>(T value, JsonTypeInfo<T> typeInfo) where T : class
     {
         var buffer = new ArrayBufferWriter<byte>();
         using var writer = new Utf8JsonWriter(buffer);
-        JsonSerializer.Serialize(writer, value);
+        JsonSerializer.Serialize(writer, value, typeInfo);
         return buffer.WrittenSpan;
     }
 
-    /// <summary>
-    ///     Parses the text representing a single JSON value into a <typeparamref name="T"/>.
-    /// </summary>
-    /// <typeparam name="T">The type to deserialize the JSON value into.</typeparam>
-    /// <param name="buffer">JSON text to parse.</param>
-    /// <returns>A <typeparamref name="T"/> representation of the JSON value.</returns>
-    /// <exception cref="JsonException">The JSON is invalid, <typeparamref name="T"/> is not compatible with the JSON, or there is remaining data in the Stream.</exception>
-    /// <exception cref="NotSupportedException">There is no compatible <seealso cref="JsonConverter"/> for <typeparamref name="T"/> or its serializable members.</exception>
-    public static T Deserialize<T>(ReadOnlySpan<byte> buffer) where T : class
+    /// <inheritdoc cref="ISerializationService.Deserialize{T}(ReadOnlySpan{byte}, JsonTypeInfo{T})" />
+    public static T? Deserialize<T>(ReadOnlySpan<byte> buffer, JsonTypeInfo<T> typeInfo) where T : class
     {
-        var payload = new Utf8JsonReader(buffer);
-        return JsonSerializer.Deserialize<T>(ref payload)!;
+        return JsonSerializer.Deserialize(buffer, typeInfo); 
     }
 }

--- a/AdvancedSystems.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/AdvancedSystems.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddCachingService(this IServiceCollection services)
     {
+        services.AddSerializationService();
         services.TryAdd(ServiceDescriptor.Singleton<ICachingService, CachingService>());
         return services;
     }

--- a/AdvancedSystems.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/AdvancedSystems.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -28,4 +28,10 @@ public static class ServiceCollectionExtensions
         services.TryAdd(ServiceDescriptor.Singleton<IMessageBus, MessageBus>());
         return services;
     }
+
+    public static IServiceCollection AddSerializationService(this IServiceCollection services)
+    {
+        services.TryAdd(ServiceDescriptor.Scoped<ISerializationService, SerializationService>());
+        return services;
+    }
 }

--- a/AdvancedSystems.Core/Services/CachingService.cs
+++ b/AdvancedSystems.Core/Services/CachingService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Text.Json.Serialization.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 
 using AdvancedSystems.Core.Abstractions;
@@ -21,27 +22,27 @@ public sealed class CachingService : ICachingService
     #region Methods
 
     /// <inheritdoc />
-    public async ValueTask SetAsync<T>(string key, T value, CancellationToken cancellationToken = default) where T : class
+    public async ValueTask SetAsync<T>(string key, T value, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default) where T : class
     {
         var options = new CacheOptions();
-        await this.SetAsync<T>(key, value, options, cancellationToken);
+        await this.SetAsync(key, value, jsonTypeInfo, options, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async ValueTask SetAsync<T>(string key, T value, CacheOptions options, CancellationToken cancellationToken = default) where T : class
+    public async ValueTask SetAsync<T>(string key, T value, JsonTypeInfo<T> jsonTypeInfo, CacheOptions options, CancellationToken cancellationToken = default) where T : class
     {
-        byte[] cacheValue = ObjectSerializer.Serialize(value).ToArray();
+        byte[] cacheValue = ObjectSerializer.Serialize(value, jsonTypeInfo).ToArray();
         await this._distributedCache.SetAsync(key, cacheValue, options, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async ValueTask<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default) where T : class
+    public async ValueTask<T?> GetAsync<T>(string key, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default) where T : class
     {
         byte[]? cachedValues = await this._distributedCache.GetAsync(key, cancellationToken);
 
         if (cachedValues == null || cachedValues.Length == 0) return default;
 
-        T @object = ObjectSerializer.Deserialize<T>(cachedValues);
+        T? @object = ObjectSerializer.Deserialize(cachedValues, jsonTypeInfo);
         return @object;
     }
 

--- a/AdvancedSystems.Core/Services/CachingService.cs
+++ b/AdvancedSystems.Core/Services/CachingService.cs
@@ -17,7 +17,7 @@ public sealed class CachingService : ICachingService
     public CachingService(IDistributedCache distributedCache, ISerializationService serializationService)
     {
         this._distributedCache = distributedCache;
-        _serializationService = serializationService;
+        this._serializationService = serializationService;
     }
 
     #region Methods

--- a/AdvancedSystems.Core/Services/SerializationService.cs
+++ b/AdvancedSystems.Core/Services/SerializationService.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Text.Json.Serialization.Metadata;
+
+using AdvancedSystems.Core.Abstractions;
+using AdvancedSystems.Core.Common;
+
+namespace AdvancedSystems.Core.Services;
+
+/// <inheritdoc cref="ISerializationService" />
+public sealed class SerializationService : ISerializationService
+{
+    #region Methods
+
+    /// <inheritdoc />
+    public ReadOnlySpan<byte> Serialize<T>(T value, JsonTypeInfo<T> typeInfo) where T : class
+    {
+        return ObjectSerializer.Serialize(value, typeInfo);
+    }
+
+    /// <inheritdoc />
+    public T? Deserialize<T>(ReadOnlySpan<byte> buffer, JsonTypeInfo<T> typeInfo) where T : class
+    {
+        return ObjectSerializer.Deserialize(buffer, typeInfo);
+    }
+
+    #endregion
+}

--- a/AdvancedSystems.Core/Services/SerializationService.cs
+++ b/AdvancedSystems.Core/Services/SerializationService.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text.Json.Serialization.Metadata;
+﻿using System.Text.Json.Serialization.Metadata;
 
 using AdvancedSystems.Core.Abstractions;
 using AdvancedSystems.Core.Common;
@@ -12,13 +11,13 @@ public sealed class SerializationService : ISerializationService
     #region Methods
 
     /// <inheritdoc />
-    public ReadOnlySpan<byte> Serialize<T>(T value, JsonTypeInfo<T> typeInfo) where T : class
+    public byte[] Serialize<T>(T value, JsonTypeInfo<T> typeInfo) where T : class
     {
-        return ObjectSerializer.Serialize(value, typeInfo);
+        return ObjectSerializer.Serialize(value, typeInfo).ToArray();
     }
 
     /// <inheritdoc />
-    public T? Deserialize<T>(ReadOnlySpan<byte> buffer, JsonTypeInfo<T> typeInfo) where T : class
+    public T? Deserialize<T>(byte[] buffer, JsonTypeInfo<T> typeInfo) where T : class
     {
         return ObjectSerializer.Deserialize(buffer, typeInfo);
     }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,6 +31,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,3 +1,56 @@
 # Getting Started
 
-TODO
+## Serialization Service
+
+### Basic Usage
+
+The default implementation of `ISerializationService`, and by extension, `ICachingService`,
+is supposed to be used with source generation (from `System.Text.Json`) to serialize or
+deserialize a type. This facilitates assembly trimming and improves performance by
+reducing private memory usage. By default, `System.Text.Json` uses reflection to collect
+and cache metadata.
+
+To disable the default behavior, set the following MSBuild property in your project file:
+
+```xml
+<PropertyGroup>
+  <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+</PropertyGroup>
+```
+
+Create a partial class that derives from `JsonSerializerContext`.
+
+- For an entire context, use the `JsonSourceGenerationOptionsAttribute.GenerationMode` property.
+- For an individual type, use the `JsonSerializableAttribute.GenerationMode` property.
+
+```csharp
+// data structure to serialize/deserialize
+internal record Person(string FirstName, string LastName);
+
+// context class configured to do source generation for the preceding Person record
+[JsonSerializable(typeof(Person), GenerationMode = JsonSourceGenerationMode.Default)]
+internal partial class PersonContext : JsonSerializerContext;
+```
+
+Next, add `ISerializationService` to the DI container and consume the service:
+
+```csharp
+// register service
+services.AddSerializationService();
+
+// retrieve an instance of a service
+var serializationService = hostBuilder.Services.GetService<ISerializationService>();
+
+// serialize and deserialize an object
+var serialized = serializationService.Serialize(expected, PersonContext.Default.Person);
+var actual = serializationService.Deserialize(serialized, PersonContext.Default.Person);
+```
+
+### Further Reading
+
+- https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation
+
+### See Also
+
+- [`ObjectSerializer`](/api/AdvancedSystems.Core.Common.ObjectSerializer.html)
+- [`CachingService`](/api/AdvancedSystems.Core.Services.CachingService.html)


### PR DESCRIPTION
## Subtask 1

- [x] Fix release build error: serialization and deserialization requires a JsonSerializerContext when trimming is enabled.
- [x] Add a minimal working example in the documentation

## Subtask 2

- [x] Define `ISerializationService` and add doc strings
- [x] Implement `SerializationService`
- [x] Implement `AddSerializationService`
- [x] Publish a new version of `AdvancedSystems.Core.Abstractions`
- [x] Write unit tests for `SerializationService` and `AddSerializationService`

## Subtask 3

- [x] Refactor `CachingService` and use `SerializationService` instead
- [x] Register `SerializationService` in `AddCachingService` as scoped service
- [x] Update unit tests (`CachingServiceFixture`, `CachingServiceTests`)